### PR TITLE
feat/issue98: 単体ページのOpticalIconをクリックで総合ページへの遷移

### DIFF
--- a/src/app/calendars/[id]/client-content.tsx
+++ b/src/app/calendars/[id]/client-content.tsx
@@ -3,6 +3,7 @@
 import { format } from "date-fns";
 import { ArrowLeft, CalendarDays, X } from "lucide-react";
 import Image from "next/image";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
@@ -378,9 +379,9 @@ export function CalendarDetailClient({
           </Button>
 
           {/* OptiCal ロゴ */}
-          <div className="flex items-center shrink-0">
+          <Link href="/" className="flex shrink-0 items-center">
             <Image src="/optical.png" alt="OptiCal" width={36} height={36} />
-          </div>
+          </Link>
 
           {/* カレンダー切り替え */}
           <CalendarSwitcher


### PR DESCRIPTION
<!-- for GitHub Copilot review rule -->
<!--
PRのタイトルを修正すべきであれば指摘してください
日本語でレビューしてください
-->
<!-- for GitHub Copilot review  rule-->

## 概要
feat/issue98
<!-- issueがあれば以下に記載する -->
<!-- close #xxx -->

<!-- 関連するBacklogがあれば紐づける -->
<!-- https://world-wing.backlog.com/projects/PSC -->

## 変更内容
単体スケジュール画面でOpticalアイコンを選択すると総合スケジュール画面に遷移
<!-- - このプルリクで何をしたのか？ -->

### スクリーンショット

<!-- 画面で見せれるものであれば必ずスクリーンショットを添付する -->
