### PR TITLE
fix/issue115: タイムラインでの終日予定イベントの不具合修正

### DIFF
--- a/src/components/molecules/FullDayEvent/CalendarFullDayEventCard.tsx
+++ b/src/components/molecules/FullDayEvent/CalendarFullDayEventCard.tsx
@@ -5,14 +5,24 @@ import { cn, getContrastTextColor } from "@/utils_constants_styles/utils";
 /**
  * タイムライン（時間軸）用の終日判定
  *
- * - ISO文字列で「00:00:00 〜 23:59」を満たす場合に
- *   「単日終日イベント」とみなす
+ * - isAllDay フラグが存在すればそれを優先（推奨）
+ * - フラグがない場合のみ、ISO文字列で「00:00:00 〜 23:59」を満たす場合に
+ *   「単日終日イベント」とみなす（後方互換性のため）
  * - 日を跨ぐ（複数日）イベントはここでは考慮しない
  *
  * ※ 日跨ぎイベントについては UI 表現や分割ロジックが変わるため、
  *    別 issue で variant を利用した実装を行う想定
  */
-export function isFullDayEventISO(startIso: string, endIso?: string): boolean {
+export function isFullDayEventISO(
+  startIso: string,
+  endIso?: string,
+  isAllDay?: boolean,
+): boolean {
+  // isAllDay フラグが既に存在すればそれを優先
+  if (isAllDay !== undefined) {
+    return isAllDay;
+  }
+
   if (!endIso) {
     return false;
   }

--- a/src/components/organisms/DailyPanel/DailyPanel.tsx
+++ b/src/components/organisms/DailyPanel/DailyPanel.tsx
@@ -33,6 +33,7 @@ export type DailyPanelItem = {
   calendarColor?: string;
   members?: string[];
   calendarName?: string;
+  isAllDay?: boolean;
 };
 
 export type DailyPanelProps = {
@@ -54,6 +55,12 @@ export type DailyPanelProps = {
 
 /* ===== 終日判定 ===== */
 function isAllDay(item: DailyPanelItem) {
+  // isAllDay フラグが既に存在すればそれを優先
+  if (item.isAllDay !== undefined) {
+    return item.isAllDay;
+  }
+
+  // フラグがない場合は時刻境界から推論（後方互換性のため）
   if (!item.startsAt || !item.endsAt) return false;
 
   const start = new Date(item.startsAt);
@@ -67,7 +74,6 @@ function isAllDay(item: DailyPanelItem) {
       end.getMinutes() === 59 &&
       end.getSeconds() === 59);
 
-  // 複数日にまたがる終日予定にも対応
   return isStartMidnight && isEndEndOfDay;
 }
 

--- a/src/components/organisms/GeneralCalendarBoard/GeneralCalendarBoard.tsx
+++ b/src/components/organisms/GeneralCalendarBoard/GeneralCalendarBoard.tsx
@@ -282,6 +282,7 @@ export function GeneralCalendarBoard({
                           const isAllDay = isFullDayEventISO(
                             event.item.start,
                             event.item.end,
+                            event.item.isAllDay,
                           );
 
                           return (

--- a/src/components/organisms/GeneralCalendarBoard/GeneralCalendarEventPopover.tsx
+++ b/src/components/organisms/GeneralCalendarBoard/GeneralCalendarEventPopover.tsx
@@ -247,7 +247,11 @@ export function GeneralCalendarEventPopover({
     setLocationValue(item.location ?? "");
     setTitleValue(item.title);
 
-    const isAllDay = isAllDayFromRange(initialStart, initialEnd);
+    // item.isAllDay フラグが存在すればそれを優先、なければ時刻境界から推論
+    const isAllDay =
+      item.isAllDay !== undefined
+        ? item.isAllDay
+        : isAllDayFromRange(initialStart, initialEnd);
     setIsAllDayValue(isAllDay);
 
     setStartDateValue(initialStart);

--- a/src/components/organisms/SingleCalendarBoard/SingleCalendarBoard.tsx
+++ b/src/components/organisms/SingleCalendarBoard/SingleCalendarBoard.tsx
@@ -373,6 +373,7 @@ export function SingleCalendarBoard({
                           const isAllDay = isFullDayEventISO(
                             event.item.start,
                             event.item.end,
+                            event.item.isAllDay,
                           );
 
                           return (

--- a/src/components/organisms/SingleCalendarBoard/SingleScheduleEventPopover.tsx
+++ b/src/components/organisms/SingleCalendarBoard/SingleScheduleEventPopover.tsx
@@ -253,7 +253,12 @@ export function SingleScheduleEventPopover({
     setEndDateValue(initialEnd);
     setStartTimeValue(formatTime(initialStart));
     setEndTimeValue(initialEnd ? formatTime(initialEnd) : "10:00");
-    setIsAllDayValue(isAllDayFromRange(initialStart, initialEnd));
+    // item.isAllDay フラグが存在すればそれを優先、なければ時刻境界から推論
+    setIsAllDayValue(
+      item.isAllDay !== undefined
+        ? item.isAllDay
+        : isAllDayFromRange(initialStart, initialEnd),
+    );
 
     setEditingTitle(false);
     setEditingDate(false);

--- a/src/types/schedule.ts
+++ b/src/types/schedule.ts
@@ -26,6 +26,7 @@ export type ScheduleBoardItem = {
   calendarName?: string;
   calendarColor?: string;
   calendarId?: string; // 削除用
+  isAllDay?: boolean;
 };
 
 /** カレンダー一覧取得APIのレスポンス型 */


### PR DESCRIPTION
<!-- for GitHub Copilot review rule -->
<!--
PRのタイトルを修正すべきであれば指摘してください
日本語でレビューしてください
-->
<!-- for GitHub Copilot review  rule-->

## 概要
複数日に跨る終日予定が正しく判定・表示されないバグを修正しました。
これまで、終日予定の判定ロジックは**開始日と終了日が同一日の場合のみ終日と判定**していたため、複数日にまたがる終日予定が正しく終日扱いにならず表示崩れが発生していました。
今回の修正により、**複数日に跨る終日予定も正しく終日判定される**ようになっています。

　
## 変更内容

### DailyPanel の終日判定修正

- isAllDay 関数のロジックを更新
  - これまで: 開始日と終了日が同一日の場合のみ終日判定
  - 修正後: 複数日に跨る終日予定も isAllDay と判定
- 表示崩れや終日フラグ誤判定の問題を解消

　
## 対象ファイル

- `src/components/organisms/DailyPanel/DailyPanel.tsx`

　
## 動作確認内容

- 複数日に跨る終日予定を作成した場合に、正しく終日として表示されること
- 終日予定の見た目や配置が崩れないこと
- 単日終日予定は従来通り正しく表示されること

　
## スクリーンショット
#### 実験日：2026年1月28日(火)
### 当日のみ
- 期間：1/28 ～ 1/28
- 終日予定が1日だけに設定されているケース

### 内容
- 期間：1/27 ～ 1/29
- 1/28が範囲に含まれる複数日間のケース

### 開始のみ
- 期間：1/28 ～ 1/29
- 1/28から始まる終日予定のケース（終了日は翌日以降）

### 終了のみ
- 期間：1/27 ～ 1/28
- 1/28に終了する終日予定のケース（開始日は前日以前）


<img width="1719" height="739" alt="image" src="https://github.com/user-attachments/assets/834a0db8-89af-46ac-a3ea-8c89a098e1d6" />


