### PR TITLE
fix/issue116: タイムラインにて画面サイズによる表示の不具合を修正

### DIFF
--- a/src/components/molecules/DailyTimeline/DailyTimeline.tsx
+++ b/src/components/molecules/DailyTimeline/DailyTimeline.tsx
@@ -103,9 +103,10 @@ export function DailyTimeline({
 
   /* ===== スクロール同期 ===== */
   // Reset auto-scroll flag when items change (e.g. date change)
+  // biome-ignore lint/correctness/useExhaustiveDependencies: items 変更時に自動スクロールをリセットする必要があるため
   useEffect(() => {
     hasAutoScrolledRef.current = false;
-  }, []);
+  }, [items]);
 
   useLayoutEffect(() => {
     if (hasAutoScrolledRef.current) return;
@@ -282,7 +283,7 @@ export function DailyTimeline({
                   height: ev.displayHeight,
                   left: `calc(${leftBase}px + ((100% - ${leftBase}px) / ${ev.colCount}) * ${ev.col})`,
                   width: `calc((100% - ${leftBase}px) / ${ev.colCount} - ${gap}px)`,
-                  zIndex: 10,
+                  zIndex: hoveredEventId === ev.id ? 1000 : 10,
                   opacity: mounted ? 1 : 0,
                   transform: mounted
                     ? "translateX(0)"
@@ -297,11 +298,7 @@ export function DailyTimeline({
                   onMouseEnter={() => setHoveredEventId(ev.id)}
                   onMouseLeave={() => setHoveredEventId(null)}
                 >
-                  <HoverCard
-                    open={hoveredEventId === ev.id}
-                    openDelay={120}
-                    closeDelay={120}
-                  >
+                  <HoverCard openDelay={120} closeDelay={120}>
                     <HoverCardTrigger asChild>
                       {/* タイムライン上のイベントカード */}
                       <div


### PR DESCRIPTION
<!-- for GitHub Copilot review rule -->
<!--
PRのタイトルを修正すべきであれば指摘してください
日本語でレビューしてください
-->
<!-- for GitHub Copilot review  rule-->

## 概要
画面サイズやレイアウト条件によって、**タイムライン上のイベントカードや詳細ホバーカードの位置がズレる問題**を修正しました。
これまで、横並び表示時や画面幅変更時に、イベントカードの配置計算や HoverCard の表示制御が不完全で、カード同士の重なりやホバー表示の不安定さが発生していました。

今回の修正により、画面サイズに依存しない安定したレイアウトと、意図したホバー挙動が実現されています。

　
## 変更内容

### DailyTimeline のレイアウト・挙動修正

- イベントカードのアニメーション指定を見直し
  - `transition-all`を廃止し、`opacity / transform`のみに限定
  - 不要な位置補間によるズレを防止
- HoverCard の制御方法を修正
  - hover 状態を内部 state（`hoveredEventId`）で明示的に管理
  - 横並び時でも意図しない HoverCard の表示・非表示が発生しないように調整
- z-index の整理
  - HoverCard 表示時の重なり順を安定化
  - 不要な位置補間によるズレを防止
- 時刻目盛り（スロット）描画の厳密化
  - padding を内側に寄せ、グリッド構造を純粋化
  - 画面サイズ変更時のズレを防止
- 不要な`useEffect / useLayoutEffect`の依存関係・記述を整理
　
## 対象ファイル

- `src/components/molecules/DailyTimeline/DailyTimeline.tsx`

　
## 動作確認内容

- 画面幅を変更した際に、イベントカードの位置ズレが発生しないこと
- 横並び表示時でも、イベントカード同士が正しくレイアウトされること
- HoverCard が意図したイベントに対してのみ表示されること
- HoverCard の表示位置・重なり順が安定していること
- 時刻目盛りとイベント配置のズレが発生しないこと

　
## スクリーンショット

